### PR TITLE
BestPractice Fix OnProperyChanged

### DIFF
--- a/CasualRacer/Model/Player.cs
+++ b/CasualRacer/Model/Player.cs
@@ -21,8 +21,7 @@ namespace CasualRacer.Model
                 if (direction != value)
                 {
                     direction = value;
-                    if (PropertyChanged != null)
-                        PropertyChanged(this, new PropertyChangedEventArgs("Direction"));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Direction)));
                 }
             }
         }
@@ -35,8 +34,7 @@ namespace CasualRacer.Model
                 if (position != value)
                 {
                     position = value;
-                    if (PropertyChanged != null)
-                        PropertyChanged(this, new PropertyChangedEventArgs("Position"));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Direction)));
                 }
             }
         }

--- a/CasualRacer/Model/Player.cs
+++ b/CasualRacer/Model/Player.cs
@@ -34,7 +34,7 @@ namespace CasualRacer.Model
                 if (position != value)
                 {
                     position = value;
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Direction)));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Position)));
                 }
             }
         }


### PR DESCRIPTION
C# 6 Anpassungen fuer die Ausloesung des PropertyChanged events.

?. um das Framework Null check und ThreadSafty uebernehmen zu lassen.
nameof operator um das Refactorn der Propertys zu vereinfachen.

Beides ist im C#6 dazu gekommen.

https://msdn.microsoft.com/en-us/library/dn986596.aspx?f=255&MSPPError=-2147217396
https://msdn.microsoft.com/en-us/library/dn986595.aspx
